### PR TITLE
Removed reference to SharpKit build target

### DIFF
--- a/Frameworks/JavaScript.NoClr/JavaScript.NoClr.csproj
+++ b/Frameworks/JavaScript.NoClr/JavaScript.NoClr.csproj
@@ -55,7 +55,6 @@
   </ItemGroup>
   <Import Project="..\Common.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SkcToolPath)\SharpKit.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
I had problems compiling this project when included in my own solution.
The error was about a missing "4.0.AssemblyInfo.cs" which did not exist.

With this change the project compiled.

I'm not sure what SharpKit.CSharp.targets bring to the compilation of the SDK so it might be something I missed.
