### PR TITLE
Include the 'thisArg' parameter to the Array.filter methode defined i…

### DIFF
--- a/Frameworks/JsClr/Internal/CoreEx.js
+++ b/Frameworks/JsClr/Internal/CoreEx.js
@@ -217,17 +217,17 @@ JsTypes.push({ fullname: "Array", baseTypeName: "Object", definition:
 			target.push(this[i]);
 		}
 	},
-	filter: function (pred) {
-		var item, i = 0;
-		for (var i = 0, j = this.length; i < j; i++) {
-			item = this[i];
-			if (!pred(item)) {
-				this.splice(i, 1);
-				i--; //prevent increase
-				j--; //length is decreased
-			}
-		}
-		return this;
+	filter: function (pred, thisArg) {
+	    var item, i = 0;
+	    for (var i = 0, j = this.length; i < j; i++) {
+	        item = this[i];
+	        if (!pred.call(thisArg, item)) {
+	            this.splice(i, 1);
+	            i--; //prevent increase
+	            j--; //length is decreased
+	        }
+	    }
+	    return this;
 	},
 	filterOut: function (pred) {
 		return this.filter(function (item) { return !pred(item); });


### PR DESCRIPTION
Hello Dan-el,

I think the definition of `Array.prototype.filter` in CoreEx.js is missing an extra parameter as defined on MDN:

`arr.filter(callback[, thisArg])`

If the predicate/callback wants to use the 'this' keyword and the argument has not been passed to it, a null reference exception occurs.
I've made a small change to prevent that.

Regards, 

Olivier
